### PR TITLE
Wrong estimation of d in effectsize::effectsize (one sample t-test)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,9 @@
 ## Bug fixes
 
 - Fixed miss-calculation of signed rank in `ranktransform()` ( #87 ).
-- Fixed bug in `standardize()` for standard objects with non-standard class-attributes (like vectors of class `haven_labelled` or `vctrs_vctr`).
+- Fixed bug in `standardize()` for standard objects with non-standard class-attributes (like vectors of class `haven_labelled` or `vctrs_vctr`).  
+- Fix `effectsize()` for one sample `t.test(...)` ( #95 ; thanks to pull request by @mutlusun )
+
 
 # effectsize 0.3.1
 

--- a/R/effectsize.R
+++ b/R/effectsize.R
@@ -30,7 +30,7 @@ effectsize.htest <- function(model, ...) {
     out <- t_to_d(
       unname(model$statistic),
       unname(model$parameter),
-      paired = grepl("Paired", model$method),
+      paired = grepl("Paired", model$method) | grepl("One Sample", model$method),
       ...
     )
     return(out)

--- a/tests/testthat/test-effectsize.htest.R
+++ b/tests/testthat/test-effectsize.htest.R
@@ -1,0 +1,16 @@
+if (require("testthat") && require("effectsize")) {
+  test_that("t-test", {
+
+    ## On samples
+    htest <- t.test(mtcars$mpg - 15)
+    testthat::expect_equal(effectsize::effectsize(htest)$d, 0.858, tol = 0.001)
+
+    ## paired
+    htest <- t.test(iris$Sepal.Length, iris$Sepal.Width, paired = TRUE)
+    testthat::expect_equal(effectsize::effectsize(htest)$d, 2.852, tol = 0.001)
+
+    ## two sample
+    htest <- t.test(mpg ~ am, mtcars, var.equal = TRUE)
+    testthat::expect_equal(effectsize::effectsize(htest)$d, -1.499, tol = 0.001)
+  })
+}


### PR DESCRIPTION
# Description

This PR aims at fixing a bug in the `effectsize::effectsize` function. If a t-test object is given as argument, Cohen's d is calculated. However, in the case of a one sample t-test, Cohen's d is wrong.

Here is a MWE:
```r
> x <- mtcars$mpg
> fit <- t.test(x, mu=15)
> effectsize::effectsize(fit)
   d |       95% CI
-------------------
1.72 | [0.88, 2.53]

> effectsize::cohens_d(x-15)
Cohen's d |       95% CI
------------------------
     0.84 | [0.44, 1.26]
```

The `effectsize` function calculates Cohen's d like in a two sample case instead.

# Proposed Changes

I changed the `effectsize` function so that it will detect a one sample t-test. After this change the results look like this:

```r
> x <- mtcars$mpg
> fit <- t.test(x, mu=15)
> effectsize::effectsize(fit)
   d |       95% CI
-------------------
0.86 | [0.44, 1.26]

> effectsize::cohens_d(x-15)
Cohen's d |       95% CI
------------------------
     0.84 | [0.44, 1.26]
```
I could not find out why there is a difference of .02. I assume it's a rounding error somewhere ...

Best,
mutlusun
