### PR TITLE
closes #302

### DIFF
--- a/vignettes/anovaES.Rmd
+++ b/vignettes/anovaES.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Effect sizes for ANOVAs"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08

--- a/vignettes/bayesian_models.Rmd
+++ b/vignettes/bayesian_models.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Effect Sizes for Bayesian Models"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08

--- a/vignettes/convert.Rmd
+++ b/vignettes/convert.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Converting Between Indices of Effect Size"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08

--- a/vignettes/from_test_statistics.Rmd
+++ b/vignettes/from_test_statistics.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Effect Size from Test Statistics"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08

--- a/vignettes/interpret.Rmd
+++ b/vignettes/interpret.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Automated Interpretation of Indices of Effect Size"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08

--- a/vignettes/simple_htests.Rmd
+++ b/vignettes/simple_htests.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Effect Sizes for Simple Hypothesis Tests"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08

--- a/vignettes/standardize_data.Rmd
+++ b/vignettes/standardize_data.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Data Standardization"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08

--- a/vignettes/standardize_parameters.Rmd
+++ b/vignettes/standardize_parameters.Rmd
@@ -1,10 +1,6 @@
 ---
 title: "Parameter and Model Standardization"
 output: 
-  github_document:
-    toc: true
-    fig_width: 10.08
-    fig_height: 6
   rmarkdown::html_vignette:
     toc: true
     fig_width: 10.08


### PR DESCRIPTION
Except `README`, it is not necessary to knit by default to `github_document`. 

That's what was causing the problem since github markup doesn't support math equations. 