### PR TITLE
Fix Kendall's W with ties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# effectsize 0.7.0.9
+
+## Bug fixes
+
+- `kendalls_w()` now deals correctly with singular ties (#448).  
+
 # effectsize 0.7.0
 
 ## Breaking Changes

--- a/R/rank_effectsizes.R
+++ b/R/rank_effectsizes.R
@@ -490,6 +490,16 @@ kendalls_w <- function(x,
 
   no_ties <- apply(rankings, 1, function(x) length(x) == insight::n_unique(x))
   if (!all(no_ties)) {
+    if (verbose) {
+      warning(
+        sprintf("%d block(s) contain ties%s.",
+                sum(!no_ties),
+                ifelse(any(apply(as.data.frame(rankings)[!no_ties, ], 1, insight::n_unique) == 1),
+                       ", some containing only 1 unique ranking", "")),
+        call. = FALSE
+      )
+    }
+
     Tj <- 0
     for (i in seq_len(m)) {
       rater <- table(rankings[i, ])
@@ -616,8 +626,6 @@ kendalls_w <- function(x,
 
 .safe_ranktransform <- function(x, verbose = TRUE, ...) {
   if (insight::n_unique(x) == 1) {
-    # if (verbose) warning("Only one unique value - rank fixed at 1", call. = FALSE)
-    # return(rep(1, length(x)))
     return(rep(mean(seq_along(x)), length(x)))
   }
   datawizard::ranktransform(x, method = "average", ..., verbose = FALSE)

--- a/R/rank_effectsizes.R
+++ b/R/rank_effectsizes.R
@@ -484,21 +484,18 @@ kendalls_w <- function(x,
   m <- nrow(rankings) # judges
   R <- colSums(rankings)
 
-  if (!all(has_tie <- apply(rankings, 1, function(x) length(x) == insight::n_unique(x)))) {
-    # there are ties
-    have_ties <- rankings[!has_tie, , drop = FALSE]
-
-    Ti <- numeric(nrow(have_ties))
-    for (j in seq_len(nrow(have_ties))) {
-      gs <- have_ties[j,][duplicated(have_ties[j,])]
-      for (g in seq_along(gs)) {
-        .t <- sum(have_ties[j,] == gs[g])
-        Ti[j] <- (.t^3 - .t) + Ti[j]
-      }
+  no_ties <- apply(rankings, 1, function(x) length(x) == insight::n_unique(x))
+  if (!all(no_ties)) {
+    Tj <- 0
+    for (i in seq_len(m)) {
+      rater <- table(rankings[i, ])
+      ties <- rater[rater > 1]
+      l <- as.numeric(ties)
+      Tj <- Tj + sum(l^3 - l)
     }
 
     W <- (12 * sum(R^2) - 3 * (m^2) * n * ((n + 1)^2)) /
-      ((m^2) * (n^3 - n) - m * sum(Ti))
+      (m^2 * (n^3 - n) - m * Tj)
   } else {
     S <- var(R) * (n - 1)
     W <- (12 * S) /

--- a/R/rank_effectsizes.R
+++ b/R/rank_effectsizes.R
@@ -11,13 +11,15 @@
 #'   `rank_epsilon_squared()`) or `DV ~ groups | blocks` (for `kendalls_w()`;
 #'   See details for the `blocks` and `groups` terminology used here).
 #'   - A list of vectors (for `rank_epsilon_squared()`).
-#'   - A matrix of `blocks x groups` (for `kendalls_w()`). See details for the
-#'   `blocks` and `groups` terminology used here.
+#'   - A matrix of `blocks x groups` (for `kendalls_w()`) (or `groups x blocks`
+#'   if `blocks_on_rows = FALSE`). See details for the `blocks` and `groups`
+#'   terminology used here.
 #' @param y An optional numeric vector of data values to compare to `x`, or a
 #'   character name of one in `data`. Ignored if `x` is not a vector.
 #' @param groups,blocks A factor vector giving the group / block for the
 #'   corresponding elements of `x`, or a character name of one in `data`.
 #'   Ignored if `x` is not a vector.
+#' @param blocks_on_rows Are blocks on rows (`TRUE`) or columns (`FALSE`).
 #' @param mu a number indicating the value around which (a-)symmetry (for
 #'   one-sample or paired samples) or shift (for independent samples) is to be
 #'   estimated. See [stats::wilcox.test].
@@ -360,6 +362,7 @@ kendalls_w <- function(x,
                        groups,
                        blocks,
                        data = NULL,
+                       blocks_on_rows = TRUE,
                        ci = 0.95,
                        alternative = "greater",
                        iterations = 200,
@@ -375,6 +378,7 @@ kendalls_w <- function(x,
   }
 
   ## prep data
+  if (is.matrix(x) && !blocks_on_rows) x <- t(x)
   data <- .get_data_nested_groups(x, groups, blocks, data, ...)
   data <- stats::na.omit(data)
 
@@ -612,8 +616,9 @@ kendalls_w <- function(x,
 
 .safe_ranktransform <- function(x, verbose = TRUE, ...) {
   if (insight::n_unique(x) == 1) {
-    if (verbose) warning("Only one unique value - rank fixed at 1")
-    return(rep(1, length(x)))
+    # if (verbose) warning("Only one unique value - rank fixed at 1", call. = FALSE)
+    # return(rep(1, length(x)))
+    return(rep(mean(seq_along(x)), length(x)))
   }
   datawizard::ranktransform(x, method = "average", ..., verbose = FALSE)
 }

--- a/R/rank_effectsizes.R
+++ b/R/rank_effectsizes.R
@@ -487,16 +487,22 @@ kendalls_w <- function(x,
   if (!all(has_tie <- apply(rankings, 1, function(x) length(x) == insight::n_unique(x)))) {
     # there are ties
     have_ties <- rankings[!has_tie, , drop = FALSE]
-    Ti <- apply(have_ties, 1, function(r) {
-      ti <- apply(outer(unique(r), r, FUN = "=="), 1, sum)
-      sum(ti^3 - ti)
-    })
+
+    Ti <- numeric(nrow(have_ties))
+    for (j in seq_len(nrow(have_ties))) {
+      gs <- have_ties[j,][duplicated(have_ties[j,])]
+      for (g in seq_along(gs)) {
+        .t <- sum(have_ties[j,] == gs[g])
+        Ti[j] <- (.t^3 - .t) + Ti[j]
+      }
+    }
 
     W <- (12 * sum(R^2) - 3 * (m^2) * n * ((n + 1)^2)) /
-      ((m^2) * n * (n^2 - 1) - m * sum(Ti))
+      ((m^2) * (n^3 - n) - m * sum(Ti))
   } else {
     S <- var(R) * (n - 1)
-    W <- (12 * S) / (m^2 * (n^3 - n))
+    W <- (12 * S) /
+      (m^2 * (n^3 - n))
   }
   W
 }

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -162,6 +162,7 @@
   if (wide) {
     x <- datawizard::data_to_wide(x,
                                   values_from = "x",
+                                  rows_from = "blocks",
                                   colnames_from = "groups")
     x <- x[,-1]
   }

--- a/man/rank_biserial.Rd
+++ b/man/rank_biserial.Rd
@@ -46,6 +46,7 @@ kendalls_w(
   groups,
   blocks,
   data = NULL,
+  blocks_on_rows = TRUE,
   ci = 0.95,
   alternative = "greater",
   iterations = 200,
@@ -61,8 +62,9 @@ kendalls_w(
 \code{rank_epsilon_squared()}) or \code{DV ~ groups | blocks} (for \code{kendalls_w()};
 See details for the \code{blocks} and \code{groups} terminology used here).
 \item A list of vectors (for \code{rank_epsilon_squared()}).
-\item A matrix of \verb{blocks x groups} (for \code{kendalls_w()}). See details for the
-\code{blocks} and \code{groups} terminology used here.
+\item A matrix of \verb{blocks x groups} (for \code{kendalls_w()}) (or \verb{groups x blocks}
+if \code{blocks_on_rows = FALSE}). See details for the \code{blocks} and \code{groups}
+terminology used here.
 }}
 
 \item{y}{An optional numeric vector of data values to compare to \code{x}, or a
@@ -99,6 +101,8 @@ intervals. Only applies when \code{ci} is not \code{NULL}. (Deprecated for
 \item{groups, blocks}{A factor vector giving the group / block for the
 corresponding elements of \code{x}, or a character name of one in \code{data}.
 Ignored if \code{x} is not a vector.}
+
+\item{blocks_on_rows}{Are blocks on rows (\code{TRUE}) or columns (\code{FALSE}).}
 }
 \value{
 A data frame with the effect size (\code{r_rank_biserial},

--- a/tests/testthat/test-rankES.R
+++ b/tests/testthat/test-rankES.R
@@ -108,5 +108,17 @@ if (require("testthat") && require("effectsize")) {
 
     W <- kendalls_w(mrt ~ interaction(condition, congruency) | pno, data = dat)
     expect_equal(W[[1]], 0.4011, tolerance = 0.01)
+
+
+
+    # singular ties
+    m <- rbind(
+      c(1, 2, 3, 4),
+      c(7, 7, 7, 7), # THIS
+      c(2, 3, 1, 4)
+    )
+
+    expect_equal(W <- kendalls_w(m, ci = NULL)[[1]], 0.4666667, tolerance = 0.001)
+    expect_equal(kendalls_w(t(m), blocks_on_rows = FALSE, ci = NULL)[[1]], W)
   })
 }

--- a/tests/testthat/test-rankES.R
+++ b/tests/testthat/test-rankES.R
@@ -118,7 +118,9 @@ if (require("testthat") && require("effectsize")) {
       c(2, 3, 1, 4)
     )
 
-    expect_equal(W <- kendalls_w(m, ci = NULL)[[1]], 0.4666667, tolerance = 0.001)
-    expect_equal(kendalls_w(t(m), blocks_on_rows = FALSE, ci = NULL)[[1]], W)
+    expect_warning(kendalls_w(m, ci = NULL), "contain ties")
+    expect_warning(W <- kendalls_w(m, ci = NULL), "unique ranking")
+    expect_equal(W[[1]], 0.4666667, tolerance = 0.001)
+    expect_equal(kendalls_w(t(m), blocks_on_rows = FALSE, ci = NULL, verbose = FALSE)[[1]], W[[1]])
   })
 }


### PR DESCRIPTION
_Closing #448_

I would rather not use the formula used by `DescTools` since I can't find where it came from.

The alternative is to drop the tie-correction all together.