### PR TITLE
r_to_z

### DIFF
--- a/R/convert_stat_to_z.R
+++ b/R/convert_stat_to_z.R
@@ -1,0 +1,13 @@
+#' Convert *r* to Fisher *z'*
+#'
+#' These functions are convenience functions to convert statistics to z.
+#'
+#' @param r A correlation *r* statistic.
+#'
+#' @examples
+#' r_to_fisherz(0.5)
+#'
+#' @export
+r_to_fisherz <- function (r) {
+  (log(1 + r) - log(1 - r)) / 2
+}


### PR DESCRIPTION
Saw this post : https://twitter.com/sTeamTraen/status/1571573991667601408 and thought hey, we could add an `anova()` method to correlation objects in correlation. One thing that we lack is the `r_to_z` conversion, also implemented in https://personality-project.org/r/psych/help/fisherz.html

It's really just a draft though, not sure about the best name and location for this function (whether it should be in another file instead of its own) 
