### PR TITLE
Specify reference level when comparing two groups/levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: effectsize
 Title: Indices of Effect Size
-Version: 1.0.0
+Version: 1.0.0.1
 Authors@R: 
     c(person(given = "Mattan S.",
              family = "Ben-Shachar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# effectsize 1.0.x
+
+- `cohens_d()`, `p_superiority()`, `rank_biserial()` and their relatives gain a `reference=` argument to control which level of the group variable should be treated as the reference (thanks @profandyfield for the suggestion).
+
 # effectsize 1.0.0
 
 ***First stable release of `{effectsize}`!***

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -317,7 +317,7 @@ glass_delta <- function(x, y = NULL, data = NULL,
     paired, pooled_sd, mu, ci, ci_method, alternative, adjust,
     approximate = FALSE
   )
-  return(out)
+  out
 }
 
 #' @keywords internal

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -29,6 +29,8 @@
 #' @param adjust Should the effect size be adjusted for small-sample bias using
 #'   Hedges' method? Note that `hedges_g()` is an alias for
 #'   `cohens_d(adjust = TRUE)`.
+#' @param reference (Optional) character value of the "group" used as the
+#'   reference. By default, the _second_ group is the reference group.
 #' @param ... Arguments passed to or from other methods. When `x` is a formula,
 #'   these can be `subset` and `na.action`.
 #' @inheritParams chisq_to_phi
@@ -210,7 +212,7 @@ glass_delta <- function(x, y = NULL, data = NULL,
 
 
   alternative <- .match.alt(alternative)
-  out <- .get_data_2_samples(x, y, data, paired = paired, verbose = verbose, ...)
+  out <- .get_data_2_samples(x, y, data, paired = paired, reference = reference, verbose = verbose, ...)
   x <- out[["x"]]
   y <- out[["y"]]
   paired <- out[["paired"]]

--- a/R/cohens_d.R
+++ b/R/cohens_d.R
@@ -1,6 +1,6 @@
 #' Cohen's *d* and Other Standardized Differences
 #'
-#' Compute effect size indices for standardized differences: Cohen's *d*,
+#' Compute effect size indices for standardized mean differences: Cohen's *d*,
 #' Hedges' *g* and Glass’s *delta* (\eqn{\Delta}). (This function returns the
 #' **population** estimate.) Pair with any reported [`stats::t.test()`].
 #' \cr\cr
@@ -9,7 +9,7 @@
 #' correction for small-sample bias (using the exact method) to Cohen's *d*. For
 #' sample sizes > 20, the results for both statistics are roughly equivalent.
 #' Glass’s *delta* is appropriate when the standard deviations are significantly
-#' different between the populations, as it uses only the *second* group's
+#' different between the populations, as it uses only the reference group's
 #' standard deviation.
 #'
 #' @param x,y A numeric vector, or a character name of one in `data`.
@@ -136,6 +136,7 @@
 #' @export
 cohens_d <- function(x, y = NULL, data = NULL,
                      pooled_sd = TRUE, mu = 0, paired = FALSE,
+                     reference = NULL,
                      adjust = FALSE,
                      ci = 0.95, alternative = "two.sided",
                      verbose = TRUE, ...) {
@@ -147,6 +148,7 @@ cohens_d <- function(x, y = NULL, data = NULL,
     y = y, data = data,
     type = "d", adjust = adjust,
     pooled_sd = pooled_sd, mu = mu, paired = paired,
+    reference = reference,
     ci = ci, alternative = alternative,
     verbose = verbose,
     ...
@@ -157,6 +159,7 @@ cohens_d <- function(x, y = NULL, data = NULL,
 #' @export
 hedges_g <- function(x, y = NULL, data = NULL,
                      pooled_sd = TRUE, mu = 0, paired = FALSE,
+                     reference = NULL,
                      ci = 0.95, alternative = "two.sided",
                      verbose = TRUE, ...) {
   cl <- match.call()
@@ -169,6 +172,7 @@ hedges_g <- function(x, y = NULL, data = NULL,
 #' @export
 glass_delta <- function(x, y = NULL, data = NULL,
                         mu = 0, adjust = TRUE,
+                        reference = NULL,
                         ci = 0.95, alternative = "two.sided",
                         verbose = TRUE, ...) {
   .effect_size_difference(
@@ -176,6 +180,7 @@ glass_delta <- function(x, y = NULL, data = NULL,
     y = y, data = data,
     type = "delta",
     mu = mu, adjust = adjust,
+    reference = reference,
     ci = ci, alternative = alternative,
     verbose = verbose,
     pooled_sd = NULL, paired = FALSE,
@@ -189,10 +194,12 @@ glass_delta <- function(x, y = NULL, data = NULL,
 .effect_size_difference <- function(x, y = NULL, data = NULL,
                                     type = "d", adjust = FALSE,
                                     mu = 0, pooled_sd = TRUE, paired = FALSE,
+                                    reference = NULL,
                                     ci = 0.95, alternative = "two.sided",
                                     verbose = TRUE, ...) {
   if (type == "d" && adjust) type <- "g"
 
+  # TODO: Check if we can do anything with `reference` for these classes
   if (type != "delta") {
     if (.is_htest_of_type(x, "t-test")) {
       return(effectsize(x, type = type, verbose = verbose, data = data, ...))

--- a/R/common_language.R
+++ b/R/common_language.R
@@ -457,13 +457,13 @@ wmw_odds <- function(x, y = NULL, data = NULL,
 
       out$CI <- ci
 
-      R <- boot::boot(
+      res <- boot::boot(
         data = d,
         statistic = est,
         R = iterations
       )
 
-      bCI <- boot::boot.ci(R, conf = ci, type = "perc")[["percent"]]
+      bCI <- boot::boot.ci(res, conf = ci, type = "perc")[["percent"]]
       bCI <- utils::tail(as.vector(bCI), 2)
       out$CI_low <- bCI[1]
       out$CI_high <- bCI[2]
@@ -480,5 +480,5 @@ wmw_odds <- function(x, y = NULL, data = NULL,
       approximate = TRUE,
       table_footer = "Non-parametric CLES"
     )
-    return(out)
+    out
   }

--- a/R/common_language.R
+++ b/R/common_language.R
@@ -41,7 +41,7 @@
 #'
 #' Where \eqn{U_1}, \eqn{U_2}, and *Overlap* are agnostic to the direction of
 #' the difference between the groups, \eqn{U_3} and probability of superiority
-#' are not.
+#' are not (this can be controlled with the `reference` argument).
 #'
 #' The parametric version of these effects assumes normality of both populations
 #' and homoscedasticity. If those are not met, the non parametric versions
@@ -111,6 +111,7 @@
 #' @aliases cles
 p_superiority <- function(x, y = NULL, data = NULL,
                           mu = 0, paired = FALSE, parametric = TRUE,
+                          reference = NULL,
                           ci = 0.95, alternative = "two.sided",
                           verbose = TRUE, ...) {
   if (.is_htest_of_type(x, "(t-test|Wilcoxon)", "t-test or a Wilcoxon-test")) {
@@ -120,7 +121,7 @@ p_superiority <- function(x, y = NULL, data = NULL,
   }
 
   data <- .get_data_2_samples(x, y, data,
-    paired = paired,
+    paired = paired, reference = reference,
     allow_ordered = !parametric,
     verbose = verbose, ...
   )
@@ -244,6 +245,7 @@ cohens_u2 <- function(x, y = NULL, data = NULL,
 #' @rdname p_superiority
 cohens_u3 <- function(x, y = NULL, data = NULL,
                       mu = 0, parametric = TRUE,
+                      reference = NULL,
                       ci = 0.95, alternative = "two.sided", iterations = 200,
                       verbose = TRUE, ...) {
   if (.is_htest_of_type(x, "(t-test|Wilcoxon)", "t-test or a Wilcoxon-test")) {
@@ -254,7 +256,7 @@ cohens_u3 <- function(x, y = NULL, data = NULL,
 
 
   data <- .get_data_2_samples(x, y, data,
-    allow_ordered = !parametric,
+    allow_ordered = !parametric, reference = reference,
     verbose = verbose, ...
   )
   x <- data[["x"]]

--- a/R/means_ratio.R
+++ b/R/means_ratio.R
@@ -14,8 +14,8 @@
 #'
 #' @details
 #' The Means Ratio ranges from 0 to \eqn{\infty}, with values smaller than 1
-#' indicating that the second mean is larger than the first, values larger than
-#' 1 indicating that the second mean is smaller than the first, and values of 1
+#' indicating that the mean of the reference group is larger, values larger than
+#' 1 indicating that the mean of the reference group is smaller, and values of 1
 #' indicating that the means are equal.
 #'
 #' # Confidence (Compatibility) Intervals (CIs)
@@ -63,6 +63,7 @@
 #' @export
 means_ratio <- function(x, y = NULL, data = NULL,
                         paired = FALSE, adjust = TRUE, log = FALSE,
+                        reference = NULL,
                         ci = 0.95, alternative = "two.sided",
                         verbose = TRUE, ...) {
   alternative <- .match.alt(alternative)
@@ -70,8 +71,8 @@ means_ratio <- function(x, y = NULL, data = NULL,
   ## Prep data
   out <- .get_data_2_samples(
     x = x, y = y, data = data,
+    paired = paired, reference = reference,
     verbose = verbose,
-    paired = paired,
     ...
   )
   x <- out[["x"]]

--- a/R/means_ratio.R
+++ b/R/means_ratio.R
@@ -105,14 +105,14 @@ means_ratio <- function(x, y = NULL, data = NULL,
 
     # Calc log RR
     log_val <- .logrom_calc(
-      paired = TRUE,
       m1 = m1,
       sd1 = sd1,
       m2 = m2,
       sd2 = sd2,
       n1 = n,
       r = r,
-      adjust = adjust
+      adjust = adjust,
+      paired = TRUE
     )
   } else {
     ## ------------------------ 2-sample case -------------------------
@@ -122,14 +122,14 @@ means_ratio <- function(x, y = NULL, data = NULL,
 
     # Calc log RR
     log_val <- .logrom_calc(
-      paired = FALSE,
       m1 = m1,
       sd1 = sd1,
       n1 = n1,
       m2 = m2,
       sd2 = sd2,
       n2 = n2,
-      adjust = adjust
+      adjust = adjust,
+      paired = FALSE
     )
   }
 
@@ -176,44 +176,44 @@ means_ratio <- function(x, y = NULL, data = NULL,
     mu = 0,
     approximate = TRUE
   )
-  return(out)
+  out
 }
 
 
 #' @keywords internal
-.logrom_calc <- function(paired = FALSE,
-                         m1,
+.logrom_calc <- function(m1,
                          sd1,
                          n1,
                          m2,
                          sd2,
                          n2 = n1,
                          r = NULL,
-                         adjust = TRUE) {
+                         adjust = TRUE,
+                         paired = FALSE) {
   if (isTRUE(paired)) {
-    yi <- log(m1 / m2)
-    vi <-
+    y_i <- log(m1 / m2)
+    v_i <-
       sd1^2 / (n1 * m1^2) +
       sd2^2 / (n1 * m2^2) -
       2 * r * sd1 * sd2 / (m1 * m2 * n1)
   } else {
-    yi <- log(m1 / m2)
+    y_i <- log(m1 / m2)
     ### large sample approximation to the sampling variance (does not assume homoscedasticity)
-    vi <- sd1^2 / (n1 * m1^2) + sd2^2 / (n2 * m2^2)
+    v_i <- sd1^2 / (n1 * m1^2) + sd2^2 / (n2 * m2^2)
   }
 
 
   if (isTRUE(adjust)) {
     J <- 0.5 * (sd1^2 / (n1 * m1^2) - sd2^2 / (n2 * m2^2))
-    yi <- yi + J
+    y_i <- y_i + J
 
     Jvar <- 0.5 * (sd1^4 / (n1^2 * m1^4) - sd2^4 / (n2^2 * m2^4))
-    vi <- vi + Jvar
+    v_i <- v_i + Jvar
   }
 
 
   list(
-    log_rom = yi,
-    var_rom = vi
+    log_rom = y_i,
+    var_rom = v_i
   )
 }

--- a/R/rank_diff.R
+++ b/R/rank_diff.R
@@ -120,6 +120,7 @@
 #' @export
 rank_biserial <- function(x, y = NULL, data = NULL,
                           mu = 0, paired = FALSE,
+                          reference = NULL,
                           ci = 0.95, alternative = "two.sided",
                           verbose = TRUE, ...) {
   alternative <- .match.alt(alternative)
@@ -131,6 +132,7 @@ rank_biserial <- function(x, y = NULL, data = NULL,
   ## Prep data
   out <- .get_data_2_samples(x, y, data,
     paired = paired,
+    reference = reference,
     allow_ordered = TRUE,
     verbose = verbose, ...
   )
@@ -208,12 +210,14 @@ rank_biserial <- function(x, y = NULL, data = NULL,
 #' @rdname rank_biserial
 cliffs_delta <- function(x, y = NULL, data = NULL,
                          mu = 0,
+                         reference = NULL,
                          ci = 0.95, alternative = "two.sided",
                          verbose = TRUE, ...) {
   cl <- match.call()
   data <- .get_data_2_samples(x, y, data,
     verbose = verbose,
     allow_ordered = TRUE,
+    reference = reference,
     ...
   )
   x <- data$x

--- a/R/rank_diff.R
+++ b/R/rank_diff.R
@@ -203,7 +203,7 @@ rank_biserial <- function(x, y = NULL, data = NULL,
   attr(out, "ci_method") <- ci_method
   attr(out, "approximate") <- FALSE
   attr(out, "alternative") <- alternative
-  return(out)
+  out
 }
 
 #' @export
@@ -259,5 +259,5 @@ cliffs_delta <- function(x, y = NULL, data = NULL,
 
   u_ <- U1 / S
   f_ <- U2 / S
-  return(u_ - f_)
+  u_ - f_
 }

--- a/R/repeated_measures_d.R
+++ b/R/repeated_measures_d.R
@@ -166,9 +166,11 @@ repeated_measures_d <- function(x, y,
   }
 
   alternative <- .match.alt(alternative)
-  data <- .get_data_paired(x, y, data = data, method = method,
-                           reference = reference,
-                           verbose = verbose, ...)
+  data <- .get_data_paired(x, y,
+    data = data, method = method,
+    reference = reference,
+    verbose = verbose, ...
+  )
 
   if (method %in% c("d", "r")) {
     values <- .replication_d(data, mu = mu, method = method)

--- a/R/repeated_measures_d.R
+++ b/R/repeated_measures_d.R
@@ -157,6 +157,7 @@ repeated_measures_d <- function(x, y,
                                 data = NULL,
                                 mu = 0, method = c("rm", "av", "z", "b", "d", "r"),
                                 adjust = TRUE,
+                                reference = NULL,
                                 ci = 0.95, alternative = "two.sided",
                                 verbose = TRUE, ...) {
   method <- match.arg(method)
@@ -165,7 +166,9 @@ repeated_measures_d <- function(x, y,
   }
 
   alternative <- .match.alt(alternative)
-  data <- .get_data_paired(x, y, data = data, method = method, verbose = verbose, ...)
+  data <- .get_data_paired(x, y, data = data, method = method,
+                           reference = reference,
+                           verbose = verbose, ...)
 
   if (method %in% c("d", "r")) {
     values <- .replication_d(data, mu = mu, method = method)

--- a/R/repeated_measures_d.R
+++ b/R/repeated_measures_d.R
@@ -222,7 +222,7 @@ repeated_measures_d <- function(x, y,
     mu, ci, ci_method, alternative,
     approximate = FALSE
   )
-  return(out)
+  out
 }
 
 #' @rdname repeated_measures_d

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -119,6 +119,7 @@
 
 #' @keywords internal
 .get_data_paired <- function(x, y = NULL, data = NULL, method,
+                             reference = NULL,
                              verbose = TRUE, ...) {
   if (inherits(x, "formula")) {
     formula_error <-
@@ -137,6 +138,9 @@
 
       if (method %in% c("d", "r")) {
         mf[[2]] <- as.factor(mf[[2]])
+        if (!is.null(reference)) {
+          mf[[2]] <- relevel(mf[[2]], ref = reference)
+        }
         mf[[3]] <- as.factor(mf[[3]])
         colnames(mf) <- c("y", "condition", "id")
         return(mf)
@@ -160,6 +164,8 @@
         insight::format_error(formula_error)
       }
       x <- mf[[1]]
+      s <- colnames(mf)[1]
+      colnames(x) <- regmatches(s, regexec("Pair\\((.*), (.*)\\)", s))[[1]][-1]
     } else {
       insight::format_error(formula_error)
     }
@@ -170,8 +176,13 @@
   }
 
   if (inherits(x, "Pair")) {
-    y <- x[, 2]
-    x <- x[, 1]
+    if (is.null(reference)) {
+      y <- x[, 2]
+      x <- x[, 1]
+    } else {
+      y <- x[, reference]
+      x <- x[, setdiff(colnames(x), reference)]
+    }
   }
 
   # x should be a numeric vector or a Pair:

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -118,7 +118,7 @@
 }
 
 #' @keywords internal
-.get_data_paired <- function(x, y = NULL, data = NULL, method,
+.get_data_paired <- function(x, y = NULL, data = NULL, method = NULL,
                              reference = NULL,
                              verbose = TRUE, ...) {
   if (inherits(x, "formula")) {
@@ -140,7 +140,7 @@
       mf[[3]] <- as.factor(mf[[3]])
 
       if (!is.null(reference)) {
-        mf[[2]] <- relevel(mf[[2]], ref = reference)
+        mf[[2]] <- stats::relevel(mf[[2]], ref = reference)
       }
 
       if (method %in% c("d", "r")) {

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -64,7 +64,7 @@
       x <- x[, 1]
     } else {
       y <- x[, reference]
-      x <- x[, setdiff(names(data), reference)]
+      x <- x[, setdiff(colnames(x), reference)]
     }
     paired <- TRUE
   }
@@ -88,7 +88,7 @@
         y <- data[[2]]
       } else {
         y <- data[[reference]]
-        x <- data[[setdiff(names(data), reference)]]
+        x <- data[[setdiff(colnames(data), reference)]]
       }
     }
 

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -136,12 +136,14 @@
       mf <- .resolve_formula(x, data, ...)
       mf <- stats::na.omit(mf)
 
+      mf[[2]] <- as.factor(mf[[2]])
+      mf[[3]] <- as.factor(mf[[3]])
+
+      if (!is.null(reference)) {
+        mf[[2]] <- relevel(mf[[2]], ref = reference)
+      }
+
       if (method %in% c("d", "r")) {
-        mf[[2]] <- as.factor(mf[[2]])
-        if (!is.null(reference)) {
-          mf[[2]] <- relevel(mf[[2]], ref = reference)
-        }
-        mf[[3]] <- as.factor(mf[[3]])
         colnames(mf) <- c("y", "condition", "id")
         return(mf)
       }

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -88,7 +88,7 @@
         y <- data[[2]]
       } else {
         y <- data[[reference]]
-        x <- data[[setdiff(colnames(data), reference)]]
+        x <- data[[setdiff(names(data), reference)]]
       }
     }
 

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -1,6 +1,7 @@
 #' @keywords internal
 .get_data_2_samples <- function(x, y = NULL, data = NULL,
                                 paired = FALSE, allow_ordered = FALSE,
+                                reference = NULL,
                                 verbose = TRUE, ...) {
   if (inherits(x, "formula")) {
     if (isTRUE(paired)) {
@@ -72,10 +73,17 @@
       }
 
       data <- Filter(length, split(x, y))
-      x <- data[[1]]
-      y <- data[[2]]
+
+      if (is.null(reference)) {
+        x <- data[[1]]
+        y <- data[[2]]
+      } else {
+        y <- data[[reference]]
+        x <- data[[setdiff(names(data), reference)]]
+      }
     }
 
+    # TODO: I think this warning is outdated.
     if (verbose && insight::n_unique(y) == 2) {
       insight::format_warning(
         "'y' is numeric but has only 2 unique values.",
@@ -103,6 +111,7 @@
 
 #' @keywords internal
 .get_data_paired <- function(x, y = NULL, data = NULL, method,
+                             reference = NULL,
                              verbose = TRUE, ...) {
   if (inherits(x, "formula")) {
     formula_error <-

--- a/R/utils_validate_input_data.R
+++ b/R/utils_validate_input_data.R
@@ -1,7 +1,7 @@
 #' @keywords internal
 .get_data_2_samples <- function(x, y = NULL, data = NULL,
-                                paired = FALSE, allow_ordered = FALSE,
-                                reference = NULL,
+                                paired = FALSE, reference = NULL,
+                                allow_ordered = FALSE,
                                 verbose = TRUE, ...) {
   if (inherits(x, "formula")) {
     if (isTRUE(paired)) {
@@ -32,6 +32,10 @@
       y <- mf[[2]]
       if (!is.factor(y)) y <- factor(y)
     }
+    if (inherits(x, "Pair")) {
+      s <- colnames(mf)[1]
+      colnames(x) <- regmatches(s, regexec("Pair\\((.*), (.*)\\)", s))[[1]][-1]
+    }
   } else {
     # Test if they are they are column names
     x <- .resolve_char(x, data)
@@ -55,8 +59,13 @@
   if (!is.numeric(x)) {
     insight::format_error("Cannot compute effect size for a non-numeric vector.")
   } else if (inherits(x, "Pair")) {
-    y <- x[, 2]
-    x <- x[, 1]
+    if (is.null(reference)) {
+      y <- x[, 2]
+      x <- x[, 1]
+    } else {
+      y <- x[, reference]
+      x <- x[, setdiff(names(data), reference)]
+    }
     paired <- TRUE
   }
 
@@ -105,13 +114,11 @@
     y <- stats::na.omit(y)
   }
 
-
   list(x = x, y = y, paired = paired)
 }
 
 #' @keywords internal
 .get_data_paired <- function(x, y = NULL, data = NULL, method,
-                             reference = NULL,
                              verbose = TRUE, ...) {
   if (inherits(x, "formula")) {
     formula_error <-

--- a/README.Rmd
+++ b/README.Rmd
@@ -138,7 +138,7 @@ And more...
 
 <!-- ### Regression Models (Standardized Parameters) -->
 
-<!-- Importantly, `effectsize` also provides [advanced methods](https://easystats.github.io/effectsize/articles/standardize_parameters.html) to compute standardized parameters for regression models. -->
+<!-- Importantly, `effectsize` also provides [advanced methods](https://easystats.github.io/parameters/articles/standardize_parameters_effsize.html) to compute standardized parameters for regression models. -->
 
 <!-- ```{r beta, warning=FALSE, message=FALSE} -->
 <!-- m <- lm(rating ~ complaints + privileges + advance, data = attitude) -->

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ epsilon_squared(model)
 And more…
 
 <!-- ### Regression Models (Standardized Parameters) -->
-<!-- Importantly, `effectsize` also provides [advanced methods](https://easystats.github.io/effectsize/articles/standardize_parameters.html) to compute standardized parameters for regression models. -->
+<!-- Importantly, `effectsize` also provides [advanced methods](https://easystats.github.io/parameters/articles/standardize_parameters_effsize.html) to compute standardized parameters for regression models. -->
 <!-- ```{r beta, warning=FALSE, message=FALSE} -->
 <!-- m <- lm(rating ~ complaints + privileges + advance, data = attitude) -->
 <!-- standardize_parameters(m) -->

--- a/effectsize.Rproj
+++ b/effectsize.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: e6b7b313-8c9f-4949-9c7b-3c2ff95eac8a
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/man/cohens_d.Rd
+++ b/man/cohens_d.Rd
@@ -13,6 +13,7 @@ cohens_d(
   pooled_sd = TRUE,
   mu = 0,
   paired = FALSE,
+  reference = NULL,
   adjust = FALSE,
   ci = 0.95,
   alternative = "two.sided",
@@ -27,6 +28,7 @@ hedges_g(
   pooled_sd = TRUE,
   mu = 0,
   paired = FALSE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -39,6 +41,7 @@ glass_delta(
   data = NULL,
   mu = 0,
   adjust = TRUE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -63,6 +66,9 @@ variance). Else the mean SD from both groups is used instead.}
 This produces an effect size that is equivalent to the one-sample effect
 size on \code{x - y}. See also \code{\link[=repeated_measures_d]{repeated_measures_d()}} for more options.}
 
+\item{reference}{(Optional) character value of the "group" used as the
+reference. By default, the \emph{second} group is the reference group.}
+
 \item{adjust}{Should the effect size be adjusted for small-sample bias using
 Hedges' method? Note that \code{hedges_g()} is an alias for
 \code{cohens_d(adjust = TRUE)}.}
@@ -84,7 +90,7 @@ A data frame with the effect size ( \code{Cohens_d}, \code{Hedges_g},
 \code{Glass_delta}) and their CIs (\code{CI_low} and \code{CI_high}).
 }
 \description{
-Compute effect size indices for standardized differences: Cohen's \emph{d},
+Compute effect size indices for standardized mean differences: Cohen's \emph{d},
 Hedges' \emph{g} and Glass’s \emph{delta} (\eqn{\Delta}). (This function returns the
 \strong{population} estimate.) Pair with any reported \code{\link[stats:t.test]{stats::t.test()}}.
 \cr\cr
@@ -93,7 +99,7 @@ difference between the means of two populations. Hedges' \emph{g} provides a
 correction for small-sample bias (using the exact method) to Cohen's \emph{d}. For
 sample sizes > 20, the results for both statistics are roughly equivalent.
 Glass’s \emph{delta} is appropriate when the standard deviations are significantly
-different between the populations, as it uses only the \emph{second} group's
+different between the populations, as it uses only the reference group's
 standard deviation.
 }
 \details{

--- a/man/effectsize.Rd
+++ b/man/effectsize.Rd
@@ -26,11 +26,11 @@ to be estimated. Default to \code{0.95} (\verb{95\%}).}
 
 \item{test}{The indices of effect existence to compute. Character (vector) or
 list with one or more of these options: \code{"p_direction"} (or \code{"pd"}),
-\code{"rope"}, \code{"p_map"}, \code{"equivalence_test"} (or \code{"equitest"}),
-\code{"bayesfactor"} (or \code{"bf"}) or \code{"all"} to compute all tests. For each
-"test", the corresponding \pkg{bayestestR} function is called (e.g.
-\code{\link[bayestestR:rope]{rope()}} or \code{\link[bayestestR:p_direction]{p_direction()}}) and its results included in the summary
-output.}
+\code{"rope"}, \code{"p_map"}, \code{"p_significance"} (or \code{"ps"}), \code{"p_rope"},
+\code{"equivalence_test"} (or \code{"equitest"}), \code{"bayesfactor"} (or \code{"bf"}) or
+\code{"all"} to compute all tests. For each "test", the corresponding
+\strong{bayestestR} function is called (e.g. \code{\link[bayestestR:rope]{rope()}} or \code{\link[bayestestR:p_direction]{p_direction()}})
+and its results included in the summary output.}
 
 \item{verbose}{Toggle off warnings.}
 

--- a/man/means_ratio.Rd
+++ b/man/means_ratio.Rd
@@ -11,6 +11,7 @@ means_ratio(
   paired = FALSE,
   adjust = TRUE,
   log = FALSE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -33,6 +34,9 @@ Defaults to \code{TRUE}; Advisable for small samples.}
 
 \item{log}{Should the log-ratio be returned? Defaults to \code{FALSE}.
 Normally distributed and useful for meta-analysis.}
+
+\item{reference}{(Optional) character value of the "group" used as the
+reference. By default, the \emph{second} group is the reference group.}
 
 \item{ci}{Confidence Interval (CI) level}
 
@@ -57,8 +61,8 @@ Computes the ratio of two means (also known as the "response ratio"; RR) of
 }
 \details{
 The Means Ratio ranges from 0 to \eqn{\infty}, with values smaller than 1
-indicating that the second mean is larger than the first, values larger than
-1 indicating that the second mean is smaller than the first, and values of 1
+indicating that the mean of the reference group is larger, values larger than
+1 indicating that the mean of the reference group is smaller, and values of 1
 indicating that the means are equal.
 }
 \note{

--- a/man/p_superiority.Rd
+++ b/man/p_superiority.Rd
@@ -18,6 +18,7 @@ p_superiority(
   mu = 0,
   paired = FALSE,
   parametric = TRUE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -56,6 +57,7 @@ cohens_u3(
   data = NULL,
   mu = 0,
   parametric = TRUE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   iterations = 200,
@@ -117,6 +119,9 @@ size on \code{x - y}.}
 \item{parametric}{Use parametric estimation (see \code{\link[=cohens_d]{cohens_d()}}) or
 non-parametric estimation (see \code{\link[=rank_biserial]{rank_biserial()}}). See details.}
 
+\item{reference}{(Optional) character value of the "group" used as the
+reference. By default, the \emph{second} group is the reference group.}
+
 \item{ci}{Confidence Interval (CI) level}
 
 \item{alternative}{a character string specifying the alternative hypothesis;
@@ -171,7 +176,7 @@ first group.
 
 Where \eqn{U_1}, \eqn{U_2}, and \emph{Overlap} are agnostic to the direction of
 the difference between the groups, \eqn{U_3} and probability of superiority
-are not.
+are not (this can be controlled with the \code{reference} argument).
 
 The parametric version of these effects assumes normality of both populations
 and homoscedasticity. If those are not met, the non parametric versions

--- a/man/rank_biserial.Rd
+++ b/man/rank_biserial.Rd
@@ -11,6 +11,7 @@ rank_biserial(
   data = NULL,
   mu = 0,
   paired = FALSE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -22,6 +23,7 @@ cliffs_delta(
   y = NULL,
   data = NULL,
   mu = 0,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -43,6 +45,9 @@ estimated. See \link[stats:wilcox.test]{stats::wilcox.test}.}
 \item{paired}{If \code{TRUE}, the values of \code{x} and \code{y} are considered as paired.
 This produces an effect size that is equivalent to the one-sample effect
 size on \code{x - y}.}
+
+\item{reference}{(Optional) character value of the "group" used as the
+reference. By default, the \emph{second} group is the reference group.}
 
 \item{ci}{Confidence Interval (CI) level}
 

--- a/man/repeated_measures_d.Rd
+++ b/man/repeated_measures_d.Rd
@@ -12,6 +12,7 @@ repeated_measures_d(
   mu = 0,
   method = c("rm", "av", "z", "b", "d", "r"),
   adjust = TRUE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -25,6 +26,7 @@ rm_d(
   mu = 0,
   method = c("rm", "av", "z", "b", "d", "r"),
   adjust = TRUE,
+  reference = NULL,
   ci = 0.95,
   alternative = "two.sided",
   verbose = TRUE,
@@ -48,6 +50,9 @@ be a formula:
 details.}
 
 \item{adjust}{Apply Hedges' small-sample bias correction? See \code{\link[=hedges_g]{hedges_g()}}.}
+
+\item{reference}{(Optional) character value of the "group" used as the
+reference. By default, the \emph{second} group is the reference group.}
 
 \item{ci}{Confidence Interval (CI) level}
 

--- a/tests/testthat/test-utils_validate_input_data.R
+++ b/tests/testthat/test-utils_validate_input_data.R
@@ -4,7 +4,8 @@ test_that(".get_data_2_samples", {
     b = 2:11,
     c = rep(letters[1:2], each = 5),
     d = c("a", "b", "b", "c", "c", "b", "c", "a", "a", "b"),
-    e = rep(0:1, each = 5)
+    e = rep(0:1, each = 5),
+    stringsAsFactors = FALSE
   )
   df$exp_a <- exp(df$a)
   a2 <- 1:11
@@ -14,16 +15,16 @@ test_that(".get_data_2_samples", {
   expect_error(d3 <- cohens_d(df$a ~ df$c), regexp = NA)
   expect_error(d4 <- cohens_d(df$a, df$c), regexp = NA)
   expect_error(d5 <- cohens_d(df$a[df$c == "a"], df$a[df$c == "b"]), regexp = NA)
-  expect_equal(d1, d2)
-  expect_equal(d1, d3)
-  expect_equal(d1, d4)
-  expect_equal(d1, d5)
+  expect_identical(d1, d2)
+  expect_identical(d1, d3)
+  expect_identical(d1, d4)
+  expect_identical(d1, d5)
 
   expect_error(cohens_d("a", "b", data = df), regexp = NA)
   expect_error(cohens_d(a2, df$b), regexp = NA)
   expect_error(cohens_d(b ~ e, data = df), regexp = NA)
 
-  expect_equal(
+  expect_identical(
     cohens_d(exp(a) ~ c, data = df),
     cohens_d("exp_a", "c", data = df)
   )
@@ -43,8 +44,8 @@ test_that(".get_data_2_samples", {
 
   expect_warning(d1 <- cohens_d(x, y), "dropped")
   expect_warning(d2 <- cohens_d(x, y, paired = TRUE), "dropped")
-  expect_equal(d1, cohens_d(1:4, 1:5), tolerance = 0.01) # indep
-  expect_equal(d2, cohens_d(1:4, c(1, 3:5), paired = TRUE), tolerance = 0.01) # paired
+  expect_identical(d1, cohens_d(1:4, 1:5)) # indep
+  expect_identical(d2, cohens_d(1:4, c(1, 3:5), paired = TRUE, verbose = FALSE)) # paired
 
   # no length problems
   expect_error(cohens_d(mtcars$mpg - 23), regexp = NA)
@@ -105,9 +106,9 @@ test_that(".get_data_2_samples | subset", {
       )
   )
 
-  expect_equal(d1, d2)
-  expect_equal(d1, d3)
-  expect_equal(d1, d4)
+  expect_identical(d1, d2)
+  expect_identical(d1, d3)
+  expect_identical(d1, d4)
 })
 
 test_that(".get_data_2_samples | reference", {
@@ -163,25 +164,28 @@ test_that(".get_data_2_samples | reference", {
   # inverse
   expect_equal(
     means_ratio(outcome ~ group_chr, data = my_tib)[[1]],
-    1 / means_ratio(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]]
+    1 / means_ratio(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]],
+    tolerance = 0.001
   )
 
   # sum to 1
   expect_equal(
     cohens_u3(outcome ~ group_chr, data = my_tib)[[1]],
-    1 - cohens_u3(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]]
+    1 - cohens_u3(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]],
+    tolerance = 0.001
   )
 
   # sum to 1
   expect_equal(
     p_superiority(outcome ~ group_chr, data = my_tib)[[1]],
-    1 - p_superiority(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]]
+    1 - p_superiority(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]],
+    tolerance = 0.001
   )
 
   # sign is opposite but so is value
   delta1 <- glass_delta(outcome ~ group_chr, data = my_tib)[[1]]
   delta2 <- glass_delta(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]]
-  expect_true(sign(delta1) == -sign(delta2))
+  expect_identical(sign(delta1), -sign(delta2))
   expect_true(abs(delta1) != abs(delta2))
 
 
@@ -196,7 +200,7 @@ test_that(".get_data_2_samples | reference", {
   # formula w/ Pair()
   expect_identical(
     hedges_g(Pair(extra.1, extra.2) ~ 1, data = sleep2, verbose = FALSE)[[1]],
-    -hedges_g(Pair(extra.1, extra.2) ~ 1, data = sleep2, , verbose = FALSE, reference = "extra.1")[[1]]
+    -hedges_g(Pair(extra.1, extra.2) ~ 1, data = sleep2, verbose = FALSE, reference = "extra.1")[[1]]
   )
 
 
@@ -212,7 +216,8 @@ test_that(".get_data_multi_group", {
     a = 1:15,
     b = 2:16,
     c = rep(letters[1:3], each = 5),
-    e = rep(0:1, length = 15)
+    e = rep(0:1, length = 15),
+    stringsAsFactors = FALSE
   )
   df$exp_a <- exp(df$a)
 
@@ -222,14 +227,14 @@ test_that(".get_data_multi_group", {
   expect_error(d4 <- rank_epsilon_squared(df$a, df$c, ci = NULL), regexp = NA)
   L <- split(df$a, df$c)
   expect_error(d5 <- rank_epsilon_squared(L, ci = NULL), regexp = NA)
-  expect_equal(d1, d2, tolerance = 0.01)
-  expect_equal(d1, d3, tolerance = 0.01)
-  expect_equal(d1, d4, tolerance = 0.01)
-  expect_equal(d1, d5, tolerance = 0.01)
+  expect_identical(d1, d2)
+  expect_identical(d1, d3)
+  expect_identical(d1, d4)
+  expect_identical(d1, d5)
 
   expect_error(rank_epsilon_squared(b ~ e, data = df), regexp = NA)
 
-  expect_equal(
+  expect_identical(
     rank_epsilon_squared(exp(a) ~ c, data = df, ci = NULL),
     rank_epsilon_squared("exp_a", "c", data = df, ci = NULL)
   )
@@ -239,14 +244,14 @@ test_that(".get_data_multi_group", {
 
   df[1, ] <- NA
   expect_warning(E1 <- rank_epsilon_squared(a ~ c, data = df, ci = NULL), "dropped")
-  expect_equal(E1, rank_epsilon_squared(df$a[-1], df$c[-1], ci = NULL))
+  expect_identical(E1, rank_epsilon_squared(df$a[-1], df$c[-1], ci = NULL))
 })
 
 
 test_that(".get_data_multi_group | subset", {
   d <- expand.grid(id = 1:30, g = 1:4)
   d$y <- rnorm(nrow(d)) + d$g
-  expect_equal(
+  expect_identical(
     rank_epsilon_squared(y ~ g, data = d, subset = g < 4, ci = NULL),
     rank_epsilon_squared(y ~ g, data = subset(d, g < 4), ci = NULL)
   )
@@ -267,7 +272,8 @@ test_that(".get_data_nested_groups", {
       "Round Out", "Narrow Angle", "Wide Angle",
       "Round Out", "Narrow Angle", "Wide Angle"
     ),
-    value = c(5.4, 5.5, 5.55, 5.85, 5.7, 5.75, 5.2, 5.6, 5.5)
+    value = c(5.4, 5.5, 5.55, 5.85, 5.7, 5.75, 5.2, 5.6, 5.5),
+    stringsAsFactors = FALSE
   )
 
   set.seed(1)
@@ -276,16 +282,16 @@ test_that(".get_data_nested_groups", {
   W3 <- kendalls_w(M2$value, M2$name, M2$id, ci = NULL)
   W4 <- kendalls_w(M2$value ~ M2$name | M2$id, ci = NULL)
 
-  expect_equal(W1, W2)
-  expect_equal(W1, W3)
-  expect_equal(W1, W4)
+  expect_identical(W1, W2)
+  expect_identical(W1, W3)
+  expect_identical(W1, W4)
 })
 
 test_that(".get_data_nested_groups | subset", {
   d <- expand.grid(id = 1:30, g = 1:4)
   d$y <- rnorm(nrow(d)) + d$g
 
-  expect_equal(
+  expect_identical(
     kendalls_w(y ~ g | id, data = d, subset = g < 4, ci = NULL),
     kendalls_w(y ~ g | id, data = subset(d, g < 4), ci = NULL)
   )
@@ -295,22 +301,22 @@ test_that(".get_data_nested_groups | subset", {
 test_that(".get_data_multivariate", {
   data("mtcars")
   D <- mahalanobis_d(mtcars[, c("mpg", "hp")])
-  expect_equal(mahalanobis_d(cbind(mpg, hp) ~ 1, data = mtcars), D)
-  expect_equal(mahalanobis_d(mpg + hp ~ 1, data = mtcars), D)
+  expect_identical(mahalanobis_d(cbind(mpg, hp) ~ 1, data = mtcars), D)
+  expect_identical(mahalanobis_d(mpg + hp ~ 1, data = mtcars), D)
 
   D <- mahalanobis_d(
     mtcars[mtcars$am == 0, c("mpg", "hp")],
     mtcars[mtcars$am == 1, c("mpg", "hp")]
   )
-  expect_equal(mahalanobis_d(cbind(mpg, hp) ~ am, data = mtcars), D)
-  expect_equal(mahalanobis_d(mpg + hp ~ am, data = mtcars), D)
+  expect_identical(mahalanobis_d(cbind(mpg, hp) ~ am, data = mtcars), D)
+  expect_identical(mahalanobis_d(mpg + hp ~ am, data = mtcars), D)
 })
 
 test_that(".get_data_multivariate | subset", {
   data("mtcars")
   D1 <- mahalanobis_d(mpg + hp ~ am, data = mtcars, subset = hp > 100)
   D2 <- mahalanobis_d(mpg + hp ~ am, data = subset(mtcars, hp > 100))
-  expect_equal(D1, D2)
+  expect_identical(D1, D2)
 })
 
 test_that(".get_data_multivariate | na.action", {
@@ -319,7 +325,7 @@ test_that(".get_data_multivariate | na.action", {
   expect_warning(mahalanobis_d(mtcars[, c("mpg", "hp")]), regexp = "dropped")
   expect_warning(mahalanobis_d(mpg + hp ~ 1, data = mtcars, na.action = na.omit), regexp = NA)
   expect_warning(D1 <- mahalanobis_d(mpg + hp ~ 1, data = mtcars), regexp = "dropped")
-  expect_equal(D1, mahalanobis_d(mpg + hp ~ 1, data = mtcars[-1, ]))
+  expect_identical(D1, mahalanobis_d(mpg + hp ~ 1, data = mtcars[-1, ]))
 })
 
 

--- a/tests/testthat/test-utils_validate_input_data.R
+++ b/tests/testthat/test-utils_validate_input_data.R
@@ -163,7 +163,7 @@ test_that(".get_data_2_samples | reference", {
   # inverse
   expect_equal(
     means_ratio(outcome ~ group_chr, data = my_tib)[[1]],
-    1/means_ratio(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]]
+    1 / means_ratio(outcome ~ group_chr, data = my_tib, reference = "No treatment")[[1]]
   )
 
   # sum to 1
@@ -189,8 +189,8 @@ test_that(".get_data_2_samples | reference", {
 
   data("sleep")
   sleep2 <- reshape(sleep,
-                    direction = "wide",
-                    idvar = "ID", timevar = "group"
+    direction = "wide",
+    idvar = "ID", timevar = "group"
   )
 
   # formula w/ Pair()
@@ -326,8 +326,8 @@ test_that(".get_data_multivariate | na.action", {
 test_that(".get_data_paired | reference", {
   data("sleep")
   sleep2 <- reshape(sleep,
-                    direction = "wide",
-                    idvar = "ID", timevar = "group"
+    direction = "wide",
+    idvar = "ID", timevar = "group"
   )
 
   # formual w/ Pair()

--- a/vignettes/convert_r_d_OR.Rmd
+++ b/vignettes/convert_r_d_OR.Rmd
@@ -138,8 +138,9 @@ Let's give it a try:
 thresh <- 22500
 
 # 2. dichotomize the outcome
-hardlyworking$salary_low <- factor(hardlyworking$salary < thresh, 
-                                   labels = c("high", "low"))
+hardlyworking$salary_low <- factor(hardlyworking$salary < thresh,
+  labels = c("high", "low")
+)
 
 # 3. Fit a logistic regression:
 fit <- glm(salary_low ~ is_senior,
@@ -160,8 +161,10 @@ by accounting for the rate of low salaries in the reference group.
 
 ```{r}
 proportions(
-  table(is_senior = hardlyworking$is_senior, 
-        salary_low = hardlyworking$salary_low), 
+  table(
+    is_senior = hardlyworking$is_senior,
+    salary_low = hardlyworking$salary_low
+  ),
   margin = 1
 )
 


### PR DESCRIPTION
Closes https://github.com/easystats/effectsize/issues/665

@strengejacke @mattansb You've done more formula text parsing than me. In `.get_data_paired()`, `Pair()` always returns column names for "x" and "y". Could you look to see if you can rename columns in `mf` to be the names passed to `Pair()` so that we can support `reference`?
